### PR TITLE
Compiler support: fix issues in registerService function

### DIFF
--- a/docs/classes/FluencePeer.html
+++ b/docs/classes/FluencePeer.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L139">internal/FluencePeer.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L140">internal/FluencePeer.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,13 +140,13 @@
 					<a name="internals" class="tsd-anchor"></a>
 					<h3>internals</h3>
 					<ul class="tsd-signatures tsd-kind-get-signature tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> internals<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>callServiceHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">CallServiceHandler</span><span class="tsd-signature-symbol">; </span>initiateFlow<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestFlow</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>initiateParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>regHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>timeout<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> }</span></li>
+						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> internals<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>callServiceHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">CallServiceHandler</span><span class="tsd-signature-symbol">; </span>initiateFlow<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestFlow</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>initiateParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span>, onStageChange<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>regHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> }</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L237">internal/FluencePeer.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L237">internal/FluencePeer.ts:237</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 									<p>Is not intended to be used manually. Subject to change</p>
 								</div>
 							</div>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{ </span>callServiceHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">CallServiceHandler</span><span class="tsd-signature-symbol">; </span>initiateFlow<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestFlow</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>initiateParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>regHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>timeout<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> }</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{ </span>callServiceHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">CallServiceHandler</span><span class="tsd-signature-symbol">; </span>initiateFlow<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestFlow</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>initiateParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span>, onStageChange<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>regHandler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> }</span></h4>
 							<ul class="tsd-parameters">
 								<li class="tsd-parameter">
 									<h5>call<wbr>Service<wbr>Handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">CallServiceHandler</span></h5>
@@ -187,11 +187,11 @@
 									</ul>
 								</li>
 								<li class="tsd-parameter">
-									<h5>initiate<wbr>Particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>initiate<wbr>Particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span>, onStageChange<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-signature">
 											<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>particle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Particle</span>, onStageChange<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -208,6 +208,27 @@
 																<p>particle to start execution of</p>
 															</div>
 														</li>
+														<li>
+															<h5>onStageChange: <span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+															<ul class="tsd-parameters">
+																<li class="tsd-parameter-signature">
+																	<ul class="tsd-signatures tsd-kind-type-literal">
+																		<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>stage<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParticleExecutionStage</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+																	</ul>
+																	<ul class="tsd-descriptions">
+																		<li class="tsd-description">
+																			<h4 class="tsd-parameters-title">Parameters</h4>
+																			<ul class="tsd-parameters">
+																				<li>
+																					<h5>stage: <span class="tsd-signature-type">ParticleExecutionStage</span></h5>
+																				</li>
+																			</ul>
+																			<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+																		</li>
+																	</ul>
+																</li>
+															</ul>
+														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 												</li>
@@ -216,7 +237,7 @@
 									</ul>
 								</li>
 								<li class="tsd-parameter">
-									<h5>reg<wbr>Handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>timeout<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span></h5>
+									<h5>reg<wbr>Handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">; </span>forParticle<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> }</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter">
 											<h5>common<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>serviceId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fnName<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GenericCallServiceHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
@@ -285,47 +306,6 @@
 												</li>
 											</ul>
 										</li>
-										<li class="tsd-parameter">
-											<h5>timeout<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
-											<ul class="tsd-parameters">
-												<li class="tsd-parameter-signature">
-													<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-type-literal">
-														<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>particleId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, handler<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
-													</ul>
-													<ul class="tsd-descriptions">
-														<li class="tsd-description">
-															<div class="tsd-comment tsd-typography">
-																<div class="lead">
-																	<p>Register handler which will be called upon particle timeout</p>
-																</div>
-															</div>
-															<h4 class="tsd-parameters-title">Parameters</h4>
-															<ul class="tsd-parameters">
-																<li>
-																	<h5>particleId: <span class="tsd-signature-type">string</span></h5>
-																</li>
-																<li>
-																	<h5>handler: <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
-																	<ul class="tsd-parameters">
-																		<li class="tsd-parameter-signature">
-																			<ul class="tsd-signatures tsd-kind-type-literal">
-																				<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
-																			</ul>
-																			<ul class="tsd-descriptions">
-																				<li class="tsd-description">
-																					<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
-																				</li>
-																			</ul>
-																		</li>
-																	</ul>
-																</li>
-															</ul>
-															<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
-														</li>
-													</ul>
-												</li>
-											</ul>
-										</li>
 									</ul>
 								</li>
 							</ul>
@@ -345,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L157">internal/FluencePeer.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L158">internal/FluencePeer.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +347,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L172">internal/FluencePeer.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L173">internal/FluencePeer.ts:173</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -399,7 +379,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L221">internal/FluencePeer.ts:221</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L222">internal/FluencePeer.ts:222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -422,7 +402,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L146">internal/FluencePeer.ts:146</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L147">internal/FluencePeer.ts:147</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/KeyPair.html
+++ b/docs/classes/KeyPair.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/KeyPair.ts#L26">internal/KeyPair.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/KeyPair.ts#L26">internal/KeyPair.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">Libp2p<wbr>Peer<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">PeerId</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/KeyPair.ts#L24">internal/KeyPair.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/KeyPair.ts#L24">internal/KeyPair.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/KeyPair.ts#L54">internal/KeyPair.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/KeyPair.ts#L54">internal/KeyPair.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Uint8Array</span></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/KeyPair.ts#L35">internal/KeyPair.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/KeyPair.ts#L35">internal/KeyPair.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/KeyPair.ts#L46">internal/KeyPair.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/KeyPair.ts#L46">internal/KeyPair.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/CallParams.html
+++ b/docs/interfaces/CallParams.html
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">init<wbr>Peer<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L37">internal/commonTypes.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L37">internal/commonTypes.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">particle<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L32">internal/commonTypes.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L32">internal/commonTypes.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L52">internal/commonTypes.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L52">internal/commonTypes.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">tetraplets<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">key</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">SecurityTetraplet</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L57">internal/commonTypes.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L57">internal/commonTypes.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L42">internal/commonTypes.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L42">internal/commonTypes.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">ttl<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L47">internal/commonTypes.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L47">internal/commonTypes.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/PeerConfig.html
+++ b/docs/interfaces/PeerConfig.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Key<wbr>Pair<span class="tsd-signature-symbol">:</span> <a href="../classes/KeyPair.html" class="tsd-signature-type" data-tsd-kind="Class">KeyPair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L77">internal/FluencePeer.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L78">internal/FluencePeer.ts:78</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">avm<wbr>Log<wbr>Level<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">LogLevel</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L71">internal/FluencePeer.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L72">internal/FluencePeer.ts:72</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">check<wbr>Connection<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L84">internal/FluencePeer.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L85">internal/FluencePeer.ts:85</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">connect<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Multiaddr</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Node</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L66">internal/FluencePeer.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L67">internal/FluencePeer.ts:67</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Ttl<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L103">internal/FluencePeer.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L104">internal/FluencePeer.ts:104</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">dial<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L96">internal/FluencePeer.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L97">internal/FluencePeer.ts:97</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">skip<wbr>Check<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L91">internal/FluencePeer.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L92">internal/FluencePeer.ts:92</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/PeerStatus.html
+++ b/docs/interfaces/PeerStatus.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Connected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L118">internal/FluencePeer.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L119">internal/FluencePeer.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,12 +119,12 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Initialized<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L113">internal/FluencePeer.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L114">internal/FluencePeer.ts:114</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Is the peer connected to network or not</p>
+							<p>Is the peer initialized or not</p>
 						</div>
 					</div>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L123">internal/FluencePeer.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L124">internal/FluencePeer.ts:124</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">relay<wbr>Peer<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L128">internal/FluencePeer.ts:128</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L129">internal/FluencePeer.ts:129</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Avm<wbr>Loglevel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">LogLevel</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/FluencePeer.ts#L50">internal/FluencePeer.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/FluencePeer.ts#L51">internal/FluencePeer.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">Peer<wbr>IdB58<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/internal/commonTypes.ts#L22">internal/commonTypes.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/internal/commonTypes.ts#L22">internal/commonTypes.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fluence<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>getPeer<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="classes/FluencePeer.html" class="tsd-signature-type" data-tsd-kind="Class">FluencePeer</a><span class="tsd-signature-symbol">; </span>getStatus<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="interfaces/PeerStatus.html" class="tsd-signature-type" data-tsd-kind="Interface">PeerStatus</a><span class="tsd-signature-symbol">; </span>start<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>config<span class="tsd-signature-symbol">?: </span><a href="interfaces/PeerConfig.html" class="tsd-signature-type" data-tsd-kind="Interface">PeerConfig</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>stop<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/index.ts#L36">index.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/index.ts#L36">index.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -234,7 +234,7 @@
 											<li class="tsd-description">
 												<div class="tsd-comment tsd-typography">
 													<div class="lead">
-														<p>Uninitializes the default peer: stops all the underltying workflows, stops the Aqua VM
+														<p>Un-initializes the default peer: stops all the underlying workflows, stops the Aqua VM
 														and disconnects from the Fluence network</p>
 													</div>
 												</div>
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/1fcd76a/src/index.ts#L25">index.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/fluencelabs/fluence-js/blob/7577170/src/index.ts#L25">index.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/internal/FluencePeer.ts
+++ b/src/internal/FluencePeer.ts
@@ -109,7 +109,7 @@ export interface PeerConfig {
  */
 export interface PeerStatus {
     /**
-     * Is the peer connected to network or not
+     * Is the peer initialized or not
      */
     isInitialized: Boolean;
 


### PR DESCRIPTION
1. Throwing error if `registerService` was called on a non-initialized peer.
2. Fix issue with incorrect context being passed to class-based implementations of user services
3. Fix type in JSDoc