### PR TITLE
Update publish branch workflow to use selfhosted registry

### DIFF
--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Import secrets
-        uses: hashicorp/vault-action@v2.4.1
+        uses: hashicorp/vault-action@v2.4.2
         with:
           url: "${{ env.VAULT_ADDR }}"
           path: jwt/github

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           BRANCH: ${{ steps.version.outputs.branch }}
           SHA: ${{ steps.version.outputs.sha }}
-          RUN: ${{ github.run.number }}
+          RUN: ${{ github.run_number }}
         run: |
             npm version prerelease --no-git-tag-version \
               --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -8,10 +8,9 @@ jobs:
     name: "Publish"
     runs-on: ubuntu-latest
 
-    retrieve-secret:
-      permissions:
-        contents: read
-        id-token: write
+    permissions:
+      contents: read
+      id-token: write
 
     env:
       VAULT_ADDR: "https://vault.fluence.dev"

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -17,8 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
+        # with:
+        #   ref: ${{ github.ref }}
 
       - name: "Setup node with self-hosted npm registry"
         uses: actions/setup-node@v2

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -64,7 +64,7 @@ jobs:
           ATTEMPT: ${{ github.run_attempt }}
         run: |
             npm version prerelease --no-git-tag-version \
-              --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}.${{ env.ATTEMPT }}
+              --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}-${{ env.ATTEMPT }}
 
       - name: "Publish to self-hosted npm repo"
-        run: npm publish --registry https://npm.fluence.dev
+        run: npm publish --tag snapshot --registry https://npm.fluence.dev

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -1,41 +1,37 @@
 name: "publish-branch"
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   npm-publish:
     name: "Publish"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
+
+    env:
+      VAULT_ADDR: "https://vault.fluence.dev"
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Get branch name
-        run: |
-          BRANCH=${GITHUB_REF#refs/*/}
-          SANITIZED=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9-]/-/g')
-          echo "BRANCH_NAME=$SANITIZED" >> $GITHUB_ENV
-      ### Set version
-      - name: Set version
-        run: npm version prerelease --no-git-tag-version --preid ${{ env.BRANCH_NAME }}-${{ github.run_number }}
+      - name: Import secrets
+        uses: hashicorp/vault-action@v2.4.1
+        with:
+          url: "${{ env.VAULT_ADDR }}"
+          path: jwt/github
+          role: ci
+          method: jwt
+          jwtGithubAudience: "https://github.com/fluencelabs"
+          jwtTtl: 300
+          exportToken: true
+          secrets: |
+            kv/npm-registry/basicauth/ci token | NODE_AUTH_TOKEN
 
-      ### Publish to NPM registry
-      - uses: actions/setup-node@v1
+      - name: "Setup node with self-hosted npm registry"
+        uses: actions/setup-node@v2
         with:
           node-version: '16'
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: cat package.json
+          registry-url: 'https://npm.fluence.dev'
 
       - run: npm i
       - run: npm run build
-
-      - run: npm publish --access public --tag=beta
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -20,10 +20,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: "Setup node"
+      - name: "Setup node with self-hosted npm registry"
         uses: actions/setup-node@v2
         with:
           node-version: "16"
+          registry-url: "https://npm.fluence.dev"
 
       - run: npm ci
       - run: npm run build
@@ -40,12 +41,6 @@ jobs:
           exportToken: false
           secrets: |
             kv/npm-registry/basicauth/ci token | NODE_AUTH_TOKEN
-
-      - name: "Setup node with self-hosted npm registry"
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-          registry-url: "https://npm.fluence.dev"
 
       - name: "Generate package version"
         id: version

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -1,9 +1,7 @@
 name: "publish-branch"
 
 on:
-  pull_request:
-    branch:
-      - "master"
+  workflow_dispatch:
 
 jobs:
   npm-publish:
@@ -19,11 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: "Setup node"
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
 
       - run: npm ci
       - run: npm run build
@@ -44,13 +44,13 @@ jobs:
       - name: "Setup node with self-hosted npm registry"
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          registry-url: 'https://npm.fluence.dev'
+          node-version: "16"
+          registry-url: "https://npm.fluence.dev"
 
       - name: "Generate package version"
         id: version
         run: |
-          BRANCH=${{ github.head_ref }}
+          BRANCH=${GITHUB_REF#refs/heads/}
           SHA=$(git rev-parse --short HEAD)
 
           echo "::set-output name=sha::$SHA"

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -8,6 +8,11 @@ jobs:
     name: "Publish"
     runs-on: ubuntu-latest
 
+    retrieve-secret:
+      permissions:
+        contents: read
+        id-token: write
+
     env:
       VAULT_ADDR: "https://vault.fluence.dev"
 

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -20,7 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Import secrets
+      - name: "Setup node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: "Import secrets"
         uses: hashicorp/vault-action@v2.4.2
         with:
           url: "${{ env.VAULT_ADDR }}"
@@ -39,5 +47,23 @@ jobs:
           node-version: '16'
           registry-url: 'https://npm.fluence.dev'
 
-      - run: npm i
-      - run: npm run build
+      - name: "Generate package version"
+        id: version
+        run: |
+          BRANCH=${{ github.head_ref }}
+          SHA=$(git rev-parse --short HEAD)
+
+          echo "::set-output name=sha::$SHA"
+          echo "::set-output name=branch::$BRANCH//[^a-zA-Z0-9-]/-}"
+
+      - name: "Set package version"
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          SHA: ${{ steps.version.outputs.sha }}
+          RUN: ${{ github.run.number }}
+        run: |
+            npm version prerelease --no-git-tag-version \
+              --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}
+
+      - name: "Publish to self-hosted npm repo"
+        run: npm publish --registry https://npm.fluence.dev

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -1,7 +1,9 @@
 name: "publish-branch"
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branch:
+      - "master"
 
 jobs:
   npm-publish:

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -12,13 +12,8 @@ jobs:
       contents: read
       id-token: write
 
-    env:
-      VAULT_ADDR: "https://vault.fluence.dev"
-
     steps:
       - uses: actions/checkout@v3
-        # with:
-        #   ref: ${{ github.ref }}
 
       - name: "Setup node with self-hosted npm registry"
         uses: actions/setup-node@v2
@@ -32,7 +27,7 @@ jobs:
       - name: "Import secrets"
         uses: hashicorp/vault-action@v2.4.2
         with:
-          url: "${{ env.VAULT_ADDR }}"
+          url: https://vault.fluence.dev
           path: jwt/github
           role: ci
           method: jwt

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -61,9 +61,10 @@ jobs:
           BRANCH: ${{ steps.version.outputs.branch }}
           SHA: ${{ steps.version.outputs.sha }}
           RUN: ${{ github.run_number }}
+          ATTEMPT: ${{ github.run_attempt }}
         run: |
             npm version prerelease --no-git-tag-version \
-              --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}
+              --preid ${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}.${{ env.ATTEMPT }}
 
       - name: "Publish to self-hosted npm repo"
         run: npm publish --registry https://npm.fluence.dev

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -23,7 +23,7 @@ jobs:
           method: jwt
           jwtGithubAudience: "https://github.com/fluencelabs"
           jwtTtl: 300
-          exportToken: true
+          exportToken: false
           secrets: |
             kv/npm-registry/basicauth/ci token | NODE_AUTH_TOKEN
 

--- a/.github/workflows/publish_branch.yml
+++ b/.github/workflows/publish_branch.yml
@@ -54,7 +54,7 @@ jobs:
           SHA=$(git rev-parse --short HEAD)
 
           echo "::set-output name=sha::$SHA"
-          echo "::set-output name=branch::$BRANCH//[^a-zA-Z0-9-]/-}"
+          echo "::set-output name=branch::${BRANCH//[^a-zA-Z0-9-]/-}"
 
       - name: "Set package version"
         env:


### PR DESCRIPTION
`publish-branch` now pushes to a self-hosted npm registry - https://npm.fluence.dev